### PR TITLE
初期表示時にAPIを叩く＋Serviceレイヤの導入

### DIFF
--- a/Konosuba.xcodeproj/project.pbxproj
+++ b/Konosuba.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AF1A623C350A787878C269B6 /* Pods_Konosuba.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AFE56591A056DB7FDC512A6 /* Pods_Konosuba.framework */; };
 		B44F07F51B25803D04C58F03 /* Pods_KonosubaTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97D0A8CBF0400A933805588B /* Pods_KonosubaTests.framework */; };
 		E3A015039AC756747FD141A4 /* Pods_KonosubaUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11A6FE842CB6D0BA69A14EEB /* Pods_KonosubaUITests.framework */; };
+		E5394A2F21CE124D00789123 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5394A2E21CE124D00789123 /* UIViewController+Rx.swift */; };
 		E5773FDA21BB9B1300653E6B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5773FD921BB9B1300653E6B /* AppDelegate.swift */; };
 		E5773FDC21BB9B1300653E6B /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5773FDB21BB9B1300653E6B /* ListViewController.swift */; };
 		E5773FDF21BB9B1300653E6B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E5773FDD21BB9B1300653E6B /* Main.storyboard */; };
@@ -48,6 +49,7 @@
 		4AFE56591A056DB7FDC512A6 /* Pods_Konosuba.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Konosuba.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		97D0A8CBF0400A933805588B /* Pods_KonosubaTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KonosubaTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D03655E0EC120DA64B081509 /* Pods-Konosuba.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Konosuba.release.xcconfig"; path = "Pods/Target Support Files/Pods-Konosuba/Pods-Konosuba.release.xcconfig"; sourceTree = "<group>"; };
+		E5394A2E21CE124D00789123 /* UIViewController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
 		E5773FD621BB9B1300653E6B /* Konosuba.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Konosuba.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5773FD921BB9B1300653E6B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E5773FDB21BB9B1300653E6B /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 			isa = PBXGroup;
 			children = (
 				E588606121BD7E6300D4694C /* SVProgressHUD+Rx.swift */,
+				E5394A2E21CE124D00789123 /* UIViewController+Rx.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -511,6 +514,7 @@
 				E59ECB3B21BBA67400641CAE /* R.generated.swift in Sources */,
 				E5C60CD521BD3D9900A5CBE4 /* ListViewReactor.swift in Sources */,
 				E588606221BD7E6300D4694C /* SVProgressHUD+Rx.swift in Sources */,
+				E5394A2F21CE124D00789123 /* UIViewController+Rx.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Konosuba.xcodeproj/project.pbxproj
+++ b/Konosuba.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		B44F07F51B25803D04C58F03 /* Pods_KonosubaTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97D0A8CBF0400A933805588B /* Pods_KonosubaTests.framework */; };
 		E3A015039AC756747FD141A4 /* Pods_KonosubaUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11A6FE842CB6D0BA69A14EEB /* Pods_KonosubaUITests.framework */; };
 		E5394A2F21CE124D00789123 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5394A2E21CE124D00789123 /* UIViewController+Rx.swift */; };
+		E5394A3221CE340100789123 /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5394A3121CE340100789123 /* ServiceProvider.swift */; };
+		E5394A3421CE347800789123 /* ProposalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5394A3321CE347800789123 /* ProposalService.swift */; };
 		E5773FDA21BB9B1300653E6B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5773FD921BB9B1300653E6B /* AppDelegate.swift */; };
 		E5773FDC21BB9B1300653E6B /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5773FDB21BB9B1300653E6B /* ListViewController.swift */; };
 		E5773FDF21BB9B1300653E6B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E5773FDD21BB9B1300653E6B /* Main.storyboard */; };
@@ -50,6 +52,8 @@
 		97D0A8CBF0400A933805588B /* Pods_KonosubaTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KonosubaTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D03655E0EC120DA64B081509 /* Pods-Konosuba.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Konosuba.release.xcconfig"; path = "Pods/Target Support Files/Pods-Konosuba/Pods-Konosuba.release.xcconfig"; sourceTree = "<group>"; };
 		E5394A2E21CE124D00789123 /* UIViewController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
+		E5394A3121CE340100789123 /* ServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProvider.swift; sourceTree = "<group>"; };
+		E5394A3321CE347800789123 /* ProposalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposalService.swift; sourceTree = "<group>"; };
 		E5773FD621BB9B1300653E6B /* Konosuba.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Konosuba.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5773FD921BB9B1300653E6B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E5773FDB21BB9B1300653E6B /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
@@ -122,6 +126,15 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		E5394A3021CE33D200789123 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				E5394A3121CE340100789123 /* ServiceProvider.swift */,
+				E5394A3321CE347800789123 /* ProposalService.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
 		E5773FCD21BB9B1300653E6B = {
 			isa = PBXGroup;
 			children = (
@@ -150,6 +163,7 @@
 			children = (
 				E588606021BD7E3F00D4694C /* Extension */,
 				E5C60CD321BD37AB00A5CBE4 /* View */,
+				E5394A3021CE33D200789123 /* Service */,
 				E5C60CD621BD42F200A5CBE4 /* Entity */,
 				E5773FD921BB9B1300653E6B /* AppDelegate.swift */,
 				E5773FDD21BB9B1300653E6B /* Main.storyboard */,
@@ -512,6 +526,8 @@
 				E5C60CD821BD430400A5CBE4 /* Proposal.swift in Sources */,
 				E5773FDA21BB9B1300653E6B /* AppDelegate.swift in Sources */,
 				E59ECB3B21BBA67400641CAE /* R.generated.swift in Sources */,
+				E5394A3421CE347800789123 /* ProposalService.swift in Sources */,
+				E5394A3221CE340100789123 /* ServiceProvider.swift in Sources */,
 				E5C60CD521BD3D9900A5CBE4 /* ListViewReactor.swift in Sources */,
 				E588606221BD7E6300D4694C /* SVProgressHUD+Rx.swift in Sources */,
 				E5394A2F21CE124D00789123 /* UIViewController+Rx.swift in Sources */,

--- a/Konosuba/AppDelegate.swift
+++ b/Konosuba/AppDelegate.swift
@@ -14,7 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let viewController = window?.rootViewController as! ListViewController
-        viewController.reactor = ListViewReactor()
+        let provider = ServiceProvider()
+        viewController.reactor = ListViewReactor(provider: provider)
         return true
     }
 

--- a/Konosuba/Extension/UIViewController+Rx.swift
+++ b/Konosuba/Extension/UIViewController+Rx.swift
@@ -1,0 +1,18 @@
+//
+//  UIViewController+Rx.swift
+//  Konosuba
+//
+//  Created by Yusuke Hosonuma on 2018/12/22.
+//  Copyright © 2018 Yusuke Hosonuma. All rights reserved.
+//
+
+import RxCocoa
+import RxSwift
+
+extension Reactive where Base: UIViewController {
+    var viewWillAppear: Observable<Void> {
+        return sentMessage(#selector(base.viewWillAppear(_:)))
+            .map { _ in () }
+            .share(replay: 1)
+    }
+}

--- a/Konosuba/Extension/UIViewController+Rx.swift
+++ b/Konosuba/Extension/UIViewController+Rx.swift
@@ -9,6 +9,9 @@
 import RxCocoa
 import RxSwift
 
+// 参考：
+// https://qiita.com/sgr-ksmt/items/e259e00f5c0a2f3109ff
+
 extension Reactive where Base: UIViewController {
     var viewWillAppear: Observable<Void> {
         return sentMessage(#selector(base.viewWillAppear(_:)))

--- a/Konosuba/Service/ProposalService.swift
+++ b/Konosuba/Service/ProposalService.swift
@@ -1,0 +1,25 @@
+//
+//  ProposalService.swift
+//  Konosuba
+//
+//  Created by Yusuke Hosonuma on 2018/12/22.
+//  Copyright © 2018 Yusuke Hosonuma. All rights reserved.
+//
+
+import RxSwift
+
+protocol ProposalServiceType {
+    func fetch() -> Observable<[Proposal]>
+}
+
+final class ProposalService: ProposalServiceType {
+    func fetch() -> Observable<[Proposal]> {
+        let url = URL(string: "https://iosdc-cfps.penginmura.tech/api/v1/proposals")!
+        return URLSession.shared.rx.data(request: URLRequest(url: url))
+            .map { data -> [Proposal] in
+                let proposals = try JSONDecoder().decode(ProposalList.self, from: data)
+                return proposals
+            }
+        // TODO: エラー処理
+    }
+}

--- a/Konosuba/Service/ServiceProvider.swift
+++ b/Konosuba/Service/ServiceProvider.swift
@@ -1,0 +1,15 @@
+//
+//  ServiceProvider.swift
+//  Konosuba
+//
+//  Created by Yusuke Hosonuma on 2018/12/22.
+//  Copyright © 2018 Yusuke Hosonuma. All rights reserved.
+//
+
+protocol ServiceProviderType {
+    var proposalService: ProposalServiceType { get }
+}
+
+final class ServiceProvider: ServiceProviderType {
+    var proposalService: ProposalServiceType = ProposalService()
+}

--- a/Konosuba/View/ListViewController.swift
+++ b/Konosuba/View/ListViewController.swift
@@ -20,7 +20,7 @@ final class ListViewController: UIViewController, StoryboardView {
 
     func bind(reactor: ListViewReactor) {
         // Action
-        rx.viewDidAppear
+        rx.viewWillAppear
             .map { Reactor.Action.initialView }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/Konosuba/View/ListViewController.swift
+++ b/Konosuba/View/ListViewController.swift
@@ -20,6 +20,11 @@ final class ListViewController: UIViewController, StoryboardView {
 
     func bind(reactor: ListViewReactor) {
         // Action
+        rx.viewDidAppear
+            .map { Reactor.Action.initialView }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         refreshButton.rx.tap
             .map { Reactor.Action.refresh }
             .bind(to: reactor.action)

--- a/Konosuba/View/ListViewReactor.swift
+++ b/Konosuba/View/ListViewReactor.swift
@@ -27,9 +27,11 @@ final class ListViewReactor: Reactor {
     }
 
     let initialState: State
+    let provider: ServiceProviderType
 
-    init() {
+    init(provider: ServiceProviderType) {
         initialState = State(proposals: [], isLoading: false)
+        self.provider = provider
     }
 
     func mutate(action: Action) -> Observable<Mutation> {
@@ -37,7 +39,7 @@ final class ListViewReactor: Reactor {
         case .initialView, .refresh:
             return Observable.concat([
                 Observable.just(Mutation.setLoading(true)),
-                search().map { Mutation.updateList($0) },
+                provider.proposalService.fetch().map { Mutation.updateList($0) },
                 Observable.just(Mutation.setLoading(false)),
             ])
         }
@@ -52,15 +54,5 @@ final class ListViewReactor: Reactor {
             state.isLoading = loading
         }
         return state
-    }
-
-    func search() -> Observable<[Proposal]> {
-        let url = URL(string: "https://iosdc-cfps.penginmura.tech/api/v1/proposals")!
-        return URLSession.shared.rx.data(request: URLRequest(url: url))
-            .map { data -> [Proposal] in
-                let proposals = try JSONDecoder().decode(ProposalList.self, from: data)
-                return proposals
-            }
-        // TODO: エラー処理
     }
 }

--- a/Konosuba/View/ListViewReactor.swift
+++ b/Konosuba/View/ListViewReactor.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 final class ListViewReactor: Reactor {
     enum Action {
+        case initialView
         case refresh
     }
 
@@ -33,7 +34,7 @@ final class ListViewReactor: Reactor {
 
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .refresh:
+        case .initialView, .refresh:
             return Observable.concat([
                 Observable.just(Mutation.setLoading(true)),
                 search().map { Mutation.updateList($0) },

--- a/Konosuba/View/ListViewReactor.swift
+++ b/Konosuba/View/ListViewReactor.swift
@@ -54,7 +54,7 @@ final class ListViewReactor: Reactor {
     }
 
     func search() -> Observable<[Proposal]> {
-        let url = URL(string: "https://iosdc-cfps.penginmura.tech/api.json")!
+        let url = URL(string: "https://iosdc-cfps.penginmura.tech/api/v1/proposals")!
         return URLSession.shared.rx.data(request: URLRequest(url: url))
             .map { data -> [Proposal] in
                 let proposals = try JSONDecoder().decode(ProposalList.self, from: data)


### PR DESCRIPTION
初期表示時にAPIを叩いてデータを取得するようにしました。（ #7 ）
また、それだけだと見どころに欠けると思ったので Service レイヤ（*1）を導入しました。

*1 Service レイヤは ReactorKit において、いわゆるModel的な処理を行う役割として切り出すことが推奨されているものです。

## TODO:

- [x] 実装
  - [x] APIエンドポイントを変更
  - [x] 初期表示時にAPIからデータを取得して表示
- [x] リファクタリング
  - [x] Service レイヤの導入